### PR TITLE
Bugfix for centering the Sumerian icon within the cell

### DIFF
--- a/src/icons/Arch_AR-VR/Arch_32/ArchAwsSumerian32.js
+++ b/src/icons/Arch_AR-VR/Arch_32/ArchAwsSumerian32.js
@@ -2,7 +2,7 @@ import * as React from "react"
 
 function SvgArchAwsSumerian32(props) {
 	return (
-		<svg xmlns="http://www.w3.org/2000/svg" {...props}>
+		<svg width={40} height={40} xmlns="http://www.w3.org/2000/svg" {...props}>
 			<defs>
 				<linearGradient
 					x1="0%"


### PR DESCRIPTION
Fixing the alignment of the Sumerian Icon.

Before: 
![image](https://github.com/boyney123/awsicons/assets/5098787/bd90954c-4a66-4dbf-9ccd-64957e627ede)

After:
<img width="460" alt="image" src="https://github.com/boyney123/awsicons/assets/5098787/a09fb768-7197-443f-a18b-746d23c929ab">

